### PR TITLE
Adding quick-add functionality to gear list page

### DIFF
--- a/src/components/GearList/CommonGearDropdown/CommonGearDropdown.tsx
+++ b/src/components/GearList/CommonGearDropdown/CommonGearDropdown.tsx
@@ -1,5 +1,13 @@
 import { useState, useEffect, useRef } from 'react';
-import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions, Field, Label } from '@headlessui/react';
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxOption,
+  ComboboxOptions,
+  ComboboxButton,
+  Field,
+  Label,
+} from '@headlessui/react';
 import type { CommonGearItem, UserGearItem } from '../../../types/gearTypes';
 import { GEAR_CATEGORIES } from '../../../constants/categories';
 import { parseFetchError } from '../../../utils/parseFetchError';
@@ -7,11 +15,18 @@ import { parseFetchError } from '../../../utils/parseFetchError';
 interface PropTypes {
   onCommonGearSelect: (gear: CommonGearItem | null) => void;
   userGearListItems: UserGearItem[] | undefined;
+  isDisabled?: boolean;
+  inputLabel?: string;
 }
 
 const apiUrl = import.meta.env.VITE_API_URL;
 
-export default function CommonGearDropdown({ onCommonGearSelect, userGearListItems }: PropTypes) {
+export default function CommonGearDropdown({
+  onCommonGearSelect,
+  userGearListItems,
+  isDisabled,
+  inputLabel = 'Select from Common Items',
+}: PropTypes) {
   const [commonGear, setCommonGear] = useState<CommonGearItem[]>([]);
   const [query, setQuery] = useState('');
   const [selectedCommonGear, setSelectedCommonGear] = useState<CommonGearItem | null>(null);
@@ -81,28 +96,34 @@ export default function CommonGearDropdown({ onCommonGearSelect, userGearListIte
     <>
       {hideComboBox ? null : (
         <Field className="combobox-field">
-          <Label className="combobox-label">Select from Common Items</Label>
+          <Label className="combobox-label">{inputLabel}</Label>
           <Combobox
             value={selectedCommonGear}
             onChange={(gear) => {
+              if (!gear || !gear._id) return;
               setSelectedCommonGear(gear);
               onCommonGearSelect(gear);
             }}
             onClose={() => setQuery('')}
+            disabled={isDisabled}
             immediate
           >
             <div className="combobox-container">
-              <ComboboxInput
-                ref={commonGearInputRef}
-                placeholder="Search & select common gear"
-                onChange={(e) => setQuery(e.target.value)}
-                onClick={() => {
-                  commonGearInputRef.current?.blur();
-                  commonGearInputRef.current?.focus();
-                }}
-                displayValue={(gear: CommonGearItem | null) => (gear ? gear.name : '')}
-                className="input-base select-base"
-              />
+              <div className="combobox-input-container">
+                <ComboboxInput
+                  ref={commonGearInputRef}
+                  placeholder="Search common gear"
+                  onChange={(e) => {
+                    setSelectedCommonGear(null);
+                    setQuery(e.target.value);
+                  }}
+                  displayValue={(gear: CommonGearItem | null) => (gear ? gear.name : '')}
+                  className="input-base"
+                />
+                <ComboboxButton className="combobox-button" aria-label="Open common gear menu">
+                  <img src="/icons/angle-down-solid-full.svg" alt="" aria-hidden="true" />
+                </ComboboxButton>
+              </div>
 
               <ComboboxOptions className="combobox-options">
                 {sortedCategories.map(([category, items]) => (

--- a/src/components/GearList/GearListByCategory/GearListByCategory.module.scss
+++ b/src/components/GearList/GearListByCategory/GearListByCategory.module.scss
@@ -1,6 +1,6 @@
 .items-list-container {
   max-width: 900px;
-  margin-top: 60px;
+  margin-top: 50px;
   border: 1px solid var(--color-light-gray);
   border-radius: 6px;
   background: rgba(255, 255, 255, 0.6);

--- a/src/components/GearList/ListItem/ListItem.tsx
+++ b/src/components/GearList/ListItem/ListItem.tsx
@@ -123,9 +123,7 @@ export default function ListItem({
       className={`w-full ${styles['list-item-container']} ${showCheckAnimation ? styles.flash : ''}`}
     >
       <article>
-        <div
-          className={`${styles['list-item']} ${checked ? styles.checked : ''} ${showCheckAnimation ? styles.flash : ''}`}
-        >
+        <div className={`${styles['list-item']} ${checked ? styles.checked : ''}`}>
           <div className={`flex-align-start ${styles['item-info']}`}>
             <div className={`flex-align-start ${styles['item-header']}`}>
               <Checkbox checked={checked} onChange={() => updateItem(!checked)} as={Fragment} disabled={itemLoading}>

--- a/src/hooks/useAddGearItem.ts
+++ b/src/hooks/useAddGearItem.ts
@@ -1,0 +1,84 @@
+import { useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import type { UserNewGearItem, UserGearItem } from '../types/gearTypes';
+import { isUserGearItem } from '../utils/validators/gearTypeValidators';
+import { parseFetchError } from '../utils/parseFetchError';
+
+const apiUrl = import.meta.env.VITE_API_URL;
+
+export default function useAddGearItem(
+  listId?: string,
+  options?: {
+    onError?: (message: string) => void;
+  },
+) {
+  const [isItemLoading, setIsItemLoading] = useState(false);
+  const [addItemError, setAddItemError] = useState<string | null>(null);
+  const { getAccessTokenSilently } = useAuth0();
+
+  const handleError = (message: string) => {
+    if (options?.onError) {
+      options.onError(message);
+    } else {
+      setAddItemError(message);
+    }
+    console.error(message);
+  };
+
+  const addGearListItem = async (itemData: UserNewGearItem): Promise<UserGearItem | null> => {
+    if (!listId) {
+      handleError('List ID is missing, unable to add gear item.');
+      return null;
+    }
+    try {
+      setIsItemLoading(true);
+
+      setAddItemError(null);
+
+      const token = await getAccessTokenSilently();
+
+      if (!token) {
+        handleError('There was a problem adding the new list item. User token not found.');
+        return null;
+      }
+
+      const res = await fetch(`${apiUrl}/gear-lists/gear-list/${listId}/items`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ itemData }),
+      });
+
+      if (!res.ok) {
+        const message = await parseFetchError(res);
+        handleError(`There was a problem adding item to the list: ${message}`);
+
+        return null;
+      }
+
+      const createdItem = await res.json();
+
+      if (isUserGearItem(createdItem)) {
+        return createdItem;
+      } else {
+        handleError('The server returned an unexpected response. Please try again.');
+
+        return null;
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        handleError(`Error adding gear item: ${error.message}`);
+      } else {
+        handleError('There was an error adding gear item');
+      }
+    } finally {
+      setIsItemLoading(false);
+    }
+
+    return null;
+  };
+
+  return { addGearListItem, isItemLoading, addItemError };
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -335,3 +335,19 @@ hr {
     text-decoration: underline;
   }
 }
+
+// ANIMATIONS
+@keyframes blueFlash {
+  0% {
+    background-color: #bfdbf4;
+    border-radius: 6px;
+  }
+  100% {
+    background-color: transparent;
+    border-radius: 6px;
+  }
+}
+
+.blue-flash {
+  animation: blueFlash 0.9s ease-out;
+}

--- a/src/pages/GearListPage/GearListPage.module.scss
+++ b/src/pages/GearListPage/GearListPage.module.scss
@@ -54,7 +54,34 @@
   }
 
   .gear-list-page-separator {
-    margin: 30px 0 40px;
+    margin: 30px 0 16px;
+  }
+
+  .page-intro-text {
+    font-size: 1.1rem;
+    margin-bottom: 30px;
+    font-style: italic;
+    font-weight: 400;
+  }
+
+  .empty-list-message {
+    width: 100%;
+    margin-top: 80px;
+    padding: 20px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.7);
+    border: 1px solid var(--color-light-gray);
+    border-radius: 8px;
+    min-height: 100px;
+    text-align: center;
+
+    p {
+      font-size: 1.2rem;
+      color: var(--color-text);
+      margin-bottom: 0;
+    }
   }
 
   @media (max-width: 700px) {

--- a/src/pages/GearListPage/GearListPage.tsx
+++ b/src/pages/GearListPage/GearListPage.tsx
@@ -118,9 +118,36 @@ export default function GearListPage() {
   useEffect(() => {
     if (!newItemId) return;
     const el = itemRefs.current[newItemId];
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
+
+    if (!el) return;
+
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+    let timeoutId: number | null = null;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          el.classList.add('blue-flash');
+
+          timeoutId = window.setTimeout(() => {
+            el.classList.remove('blue-flash');
+          }, 1000);
+
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.6 },
+    );
+
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [newItemId]);
 
   function openListItemDialog(mode: 'create' | 'edit', item?: UserGearItem) {

--- a/src/styles/_combobox.scss
+++ b/src/styles/_combobox.scss
@@ -67,3 +67,55 @@
   font-size: 0.75rem;
   color: #888;
 }
+
+.combobox-input-container {
+  display: flex;
+  margin-top: 6px;
+}
+
+.combobox-button {
+  cursor: pointer;
+  font-size: 1.1rem;
+  margin-left: 8px;
+  border: 1px solid #6fa3df;
+  border-radius: 4px;
+  padding: 0 0.6rem;
+  background-color: #fff;
+  transition:
+    border-color 0.2s,
+    box-shadow 0.2s;
+
+  display: flex;
+  align-items: center;
+
+  img {
+    width: 1.2rem;
+  }
+
+  &:focus,
+  &:hover {
+    border-color: #779fcd;
+    box-shadow: 0 0 0 3px rgba(0, 119, 255, 0.2);
+  }
+
+  &:disabled {
+    background-color: #f5f5f5;
+    color: #999;
+    cursor: not-allowed;
+  }
+
+  &::placeholder {
+    color: #aaa;
+  }
+}
+
+.common-gear-combo-container {
+  max-width: 500px;
+  margin-top: 30px;
+
+  .combobox-label {
+    font-size: 1.1rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+}

--- a/src/styles/_confirmation-modal.scss
+++ b/src/styles/_confirmation-modal.scss
@@ -101,10 +101,6 @@
 
   .combobox-field {
     text-align: left;
-
-    input {
-      margin-top: 6px;
-    }
   }
 
   .combobox-label {


### PR DESCRIPTION
- Users can now quickly add common gear items from the combobox dropdown directly on the main gear list page, rather than using the 'Add Item' dialog
- Added some new styling around added items. Including a blue-flash animation for newly added items, to indicate to users where they're showing up on the list